### PR TITLE
Avoid children rows to get the parent's height

### DIFF
--- a/bootstrap-colequalizer.js
+++ b/bootstrap-colequalizer.js
@@ -45,20 +45,20 @@
         $(element).each(function (index,el) {
             _.colReset(el);
             var tallest = 0;
-            $('[class*=col-]',el).each(function (i,e) {
+            $('> [class*=col-]',el).each(function (i,e) {
                 var testHeight = $(e).height();
                 if (testHeight > tallest) {
                     tallest = testHeight;
                 }
             });
-            $('[class*=col-]',el).height(tallest);
+            $('> [class*=col-]',el).height(tallest);
         });
 
     };
 
     ColEqualizer.prototype.colReset = function(el) {
 
-        $('[class*=col-]',el).height('auto');
+        $('> [class*=col-]',el).height('auto');
 
     };
 

--- a/bootstrap-colequalizer.js
+++ b/bootstrap-colequalizer.js
@@ -65,7 +65,7 @@
     ColEqualizer.prototype.resizeWindow = function() {
 
         var _ = this;
-        var viewWidth = window.outerWidth;
+        var viewWidth = Math.max(document.documentElement.clientWidth, window.innerWidth || 0);
 
         // If set, minWidth shows/hides the nav based on the size of the browser
         // If minWidth not set, nav will always show


### PR DESCRIPTION
I changed the selector to '>' to avoid that children rows inherit the script's height. 
