### PR TITLE
Make colequalizer compatible with jQuery 3

### DIFF
--- a/bootstrap-colequalizer.js
+++ b/bootstrap-colequalizer.js
@@ -82,7 +82,7 @@
         var _ = this;
         var $win = $(window);
 
-        $win.load(function () {
+        $win.on('load', function () {
             // Run function on window resize
             $win.on('resize', function () {
                 _.resizeWindow();

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
     "name": "bootstrap-colequalizer",
     "main": "bootstrap-colequalizer.js",
-    "version": "1.1.0",
+    "version": "1.1.2",
     "description": "A jQuery plugin that dynamically equalizes the height of uneven column elements in Bootstrap 3 grids.",
     "homepage": "https://github.com/megasmack/bootstrap-colequalizer",
     "authors": [
@@ -20,7 +20,7 @@
        ".jshintrc"
    ],
     "dependencies": {
-        "jquery": ">=1.11.*",
+        "jquery": ">=3.2.*",
         "bootstrap": ">=3.*"
     }
 }


### PR DESCRIPTION
This was a breaking change introduced in jQuery 3

Read more here: https://jquery.com/upgrade-guide/3.0/#breaking-change-load-unload-and-error-removed

Or here if link goes inactive: 

> Breaking change: .load(), .unload(), and .error() removed
> 
> These methods are shortcuts for event operations, but had several API limitations. The event .load() method conflicted with the ajax .load() method. The .error() method could not be used with window.onerror because of the way the DOM method is defined. If you need to attach events by these names, use the .on() method, e.g. change $("img").load(fn) to $("img").on("load", fn).